### PR TITLE
Upgrade to Elasticsearch 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,10 @@
     <exoplatform.kernel.version>2.5.4-GA</exoplatform.kernel.version>
     <servlet.version>3.0.1</servlet.version>
     <!-- Issue with the PLF pom parent that trigger lucene 3.6.2 (Only working with elastic version < 0.20.6) -->
-    <elasticsearch.version>1.7.2</elasticsearch.version>
-    <lucene.version>4.10.4</lucene.version>
-    <elasticsearch.mapper-attachments.version>2.7.1</elasticsearch.mapper-attachments.version>
+    <elasticsearch.version>2.2.1</elasticsearch.version>
+    <lucene.version>5.4.1</lucene.version>
+    <elasticsearch.mapper-attachments.version>2.2.1</elasticsearch.mapper-attachments.version>
+    <jna.version>4.1.0</jna.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -75,6 +76,11 @@
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>
         <version>${lucene.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>${jna.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,10 @@
     <exoplatform.kernel.version>2.5.4-GA</exoplatform.kernel.version>
     <servlet.version>3.0.1</servlet.version>
     <!-- Issue with the PLF pom parent that trigger lucene 3.6.2 (Only working with elastic version < 0.20.6) -->
-    <elasticsearch.version>2.3.1</elasticsearch.version>
+    <elasticsearch.version>2.3.2</elasticsearch.version>
     <lucene.version>5.5.0</lucene.version>
-    <elasticsearch.mapper-attachments.version>2.3.1</elasticsearch.mapper-attachments.version>
-    <elasticsearch.delete-by-query.version>2.3.1</elasticsearch.delete-by-query.version>
+    <elasticsearch.mapper-attachments.version>2.3.2</elasticsearch.mapper-attachments.version>
+    <elasticsearch.delete-by-query.version>2.3.2</elasticsearch.delete-by-query.version>
     <jna.version>4.1.0</jna.version>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <elasticsearch.version>2.3.1</elasticsearch.version>
     <lucene.version>5.4.1</lucene.version>
     <elasticsearch.mapper-attachments.version>2.3.1</elasticsearch.mapper-attachments.version>
+    <elasticsearch.delete-by-query.version>2.3.1</elasticsearch.delete-by-query.version>
     <jna.version>4.1.0</jna.version>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <servlet.version>3.0.1</servlet.version>
     <!-- Issue with the PLF pom parent that trigger lucene 3.6.2 (Only working with elastic version < 0.20.6) -->
     <elasticsearch.version>2.3.1</elasticsearch.version>
-    <lucene.version>5.4.1</lucene.version>
+    <lucene.version>5.5.0</lucene.version>
     <elasticsearch.mapper-attachments.version>2.3.1</elasticsearch.mapper-attachments.version>
     <elasticsearch.delete-by-query.version>2.3.1</elasticsearch.delete-by-query.version>
     <jna.version>4.1.0</jna.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
     <exoplatform.kernel.version>2.5.4-GA</exoplatform.kernel.version>
     <servlet.version>3.0.1</servlet.version>
     <!-- Issue with the PLF pom parent that trigger lucene 3.6.2 (Only working with elastic version < 0.20.6) -->
-    <elasticsearch.version>2.2.1</elasticsearch.version>
+    <elasticsearch.version>2.3.1</elasticsearch.version>
     <lucene.version>5.4.1</lucene.version>
-    <elasticsearch.mapper-attachments.version>2.2.1</elasticsearch.mapper-attachments.version>
+    <elasticsearch.mapper-attachments.version>2.3.1</elasticsearch.mapper-attachments.version>
     <jna.version>4.1.0</jna.version>
   </properties>
   <dependencyManagement>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -27,11 +27,15 @@
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+    </dependency>
 
     <!-- Elastic plugins -->
     <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch-mapper-attachments</artifactId>
+      <groupId>org.elasticsearch.plugin</groupId>
+      <artifactId>mapper-attachments</artifactId>
       <version>${elasticsearch.mapper-attachments.version}</version>
     </dependency>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>mapper-attachments</artifactId>
       <version>${elasticsearch.mapper-attachments.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.plugin</groupId>
+      <artifactId>delete-by-query</artifactId>
+      <version>${elasticsearch.delete-by-query.version}</version>
+    </dependency>
 
   </dependencies>
   <build>

--- a/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
+++ b/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
@@ -5,6 +5,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.mapper.attachments.MapperAttachmentsPlugin;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.plugin.deletebyquery.DeleteByQueryPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -14,6 +15,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 
 /**
@@ -48,7 +51,9 @@ public class EmbeddedESStartupServlet extends HttpServlet {
 
     // use the custom EmbeddedNode class instead of Node directly to be able to load plugins from classpath
     Environment environment = new Environment(settings.build());
-    node = new EmbeddedNode(environment, Version.CURRENT, Collections.<Class<? extends Plugin>>singletonList(MapperAttachmentsPlugin.class));
+    Collection plugins = new ArrayList<>();
+    Collections.<Class<? extends Plugin>>addAll(plugins, MapperAttachmentsPlugin.class, DeleteByQueryPlugin.class);
+    node = new EmbeddedNode(environment, Version.CURRENT, plugins);
     node.start();
   }
 

--- a/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
+++ b/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
@@ -1,8 +1,11 @@
 package org.exoplatform.addons.es;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.mapper.attachments.MapperAttachmentsPlugin;
 import org.elasticsearch.node.Node;
-import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.plugins.Plugin;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -11,6 +14,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 
 /**
  * Servlet starting an embedded Elasticsearch node during PLF startup, and stopping it when PLF stops.
@@ -42,7 +46,10 @@ public class EmbeddedESStartupServlet extends HttpServlet {
       settings.put("http.enabled", false);
     }
 
-    node = NodeBuilder.nodeBuilder().settings(settings).node();
+    // use the custom EmbeddedNode class instead of Node directly to be able to load plugins from classpath
+    Environment environment = new Environment(settings.build());
+    node = new EmbeddedNode(environment, Version.CURRENT, Collections.<Class<? extends Plugin>>singletonList(MapperAttachmentsPlugin.class));
+    node.start();
   }
 
   @Override

--- a/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
+++ b/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
@@ -1,6 +1,6 @@
 package org.exoplatform.addons.es;
 
-import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.exoplatform.services.log.ExoLogger;
@@ -26,7 +26,7 @@ public class EmbeddedESStartupServlet extends HttpServlet {
   public void init() throws ServletException {
 
     LOG.info("Initializing elasticsearch Node '" + getServletName() + "'");
-    ImmutableSettings.Builder settings = ImmutableSettings.settingsBuilder();
+    Settings.Builder settings = Settings.settingsBuilder();
 
     InputStream resourceAsStream = getServletContext().getResourceAsStream("/WEB-INF/elasticsearch.yml");
     if (resourceAsStream != null) {

--- a/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
+++ b/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
@@ -45,6 +45,9 @@ public class EmbeddedESStartupServlet extends HttpServlet {
       }
     }
 
+    // replace variable in ${...} by their value
+    settings.replacePropertyPlaceholders();
+
     if (settings.get("http.enabled") == null) {
       settings.put("http.enabled", false);
     }

--- a/war/src/main/java/org/exoplatform/addons/es/EmbeddedNode.java
+++ b/war/src/main/java/org/exoplatform/addons/es/EmbeddedNode.java
@@ -1,0 +1,31 @@
+package org.exoplatform.addons.es;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.plugins.Plugin;
+
+import java.util.Collection;
+
+/**
+ * Node allowing to declare a list of plugins
+ */
+public class EmbeddedNode extends Node {
+
+  private Version version;
+  private Collection<Class<? extends Plugin>> plugins;
+
+  public EmbeddedNode(Environment environment, Version version, Collection<Class<? extends Plugin>> classpathPlugins) {
+    super(environment, version, classpathPlugins);
+    this.version = version;
+    this.plugins = classpathPlugins;
+  }
+
+  public Collection<Class<? extends Plugin>> getPlugins() {
+    return plugins;
+  }
+
+  public Version getVersion() {
+    return version;
+  }
+}

--- a/war/src/main/webapp/WEB-INF/elasticsearch.yml
+++ b/war/src/main/webapp/WEB-INF/elasticsearch.yml
@@ -23,6 +23,10 @@ node.master: true
 #
 node.data: true
 
+# Home Path:
+#
+path.home: es
+
 # Path to directory where to store index data allocated for this node.
 #
 path.data: ${exo.data.dir}


### PR DESCRIPTION
This PR upgrades from ES 1.7 to 2.3 :
- adapt to API changes
- since it is not possible anymore to load plugins from classpath, we programmatically initialized an ES node to add the necessary plugins (EmbeddedNode)
- the Delete By Query plugin has been added since it is not part of Elasticsearch core anymore
