### PR TITLE
ES-40 bind the http port on the value define in es.http.port

### DIFF
--- a/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
+++ b/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
@@ -62,6 +62,10 @@ public class EmbeddedESStartupServlet extends HttpServlet {
       settings.put("http.enabled", false);
     }
 
+    if (Boolean.valueOf(settings.get("http.enabled")) && settings.get("http.port") == null) {
+      settings.put("http.port", 9200);
+    }
+
     // use the custom EmbeddedNode class instead of Node directly to be able to load plugins from classpath
     Environment environment = new Environment(settings.build());
     Collection plugins = new ArrayList<>();

--- a/war/src/main/webapp/WEB-INF/elasticsearch.yml
+++ b/war/src/main/webapp/WEB-INF/elasticsearch.yml
@@ -41,6 +41,10 @@ path.plugins: es/plugins
 #
 http.enabled: true
 
+# Specify the http port to use:
+#
+http.port: ${es.http.port}
+
 # Set both 'bind_host' and 'publish_host':
 #
 network.host: 127.0.0.1


### PR DESCRIPTION
Bind the embedded es on the port define on the es.http.port property if present.
Still use 9200 as default.
