### PR TITLE
ES-41 Remove clustering configuration on the default configuration

### DIFF
--- a/war/src/main/webapp/WEB-INF/elasticsearch.yml
+++ b/war/src/main/webapp/WEB-INF/elasticsearch.yml
@@ -35,6 +35,14 @@ path.data: ${exo.data.dir}
 #
 path.plugins: es/plugins
 
+# Default usage of es embedded addon is for test
+#
+index.number_of_replicas: 0
+
+# Auto-expand the number of replicas based on the number of available nodes:
+#
+index.auto_expand_replicas: 0-5
+
 ############################## Network And HTTP ###############################
 
 # Enabled HTTP completely:
@@ -45,6 +53,10 @@ http.enabled: true
 #
 network.host: 127.0.0.1
 
+# Don't try to build a cluster by default
+#
+node.local: true
+
 ################################## Discovery ##################################
 
 # Unicast discovery allows to explicitly control which nodes will be used
@@ -54,8 +66,4 @@ network.host: 127.0.0.1
 # 1. Disable multicast discovery (enabled by default):
 #
 discovery.zen.ping.multicast.enabled: false
-#
-# 2. Configure an initial list of master nodes in the cluster
-#    to perform discovery when new nodes (master or data) are started:
-#
-discovery.zen.ping.unicast.hosts: ["127.0.0.1"]
+


### PR DESCRIPTION
The default configuration should consider the deployment is not done in cluster
