### PR TITLE
ES-40 : take in acount system properties

### DIFF
--- a/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
+++ b/war/src/main/java/org/exoplatform/addons/es/EmbeddedESStartupServlet.java
@@ -2,7 +2,6 @@ package org.exoplatform.addons.es;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.env.Environment;
 import org.elasticsearch.mapper.attachments.MapperAttachmentsPlugin;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugin.deletebyquery.DeleteByQueryPlugin;
@@ -55,18 +54,14 @@ public class EmbeddedESStartupServlet extends HttpServlet {
       }
     }
 
-    // replace variable in ${...} by their value
-    settings.replacePropertyPlaceholders();
-
     if (settings.get("http.enabled") == null) {
       settings.put("http.enabled", false);
     }
 
     // use the custom EmbeddedNode class instead of Node directly to be able to load plugins from classpath
-    Environment environment = new Environment(settings.build());
     Collection plugins = new ArrayList<>();
     Collections.<Class<? extends Plugin>>addAll(plugins, MapperAttachmentsPlugin.class, DeleteByQueryPlugin.class);
-    node = new EmbeddedNode(environment, Version.CURRENT, plugins);
+    node = new EmbeddedNode(settings.build(), Version.CURRENT, plugins);
     node.start();
   }
 

--- a/war/src/main/java/org/exoplatform/addons/es/EmbeddedNode.java
+++ b/war/src/main/java/org/exoplatform/addons/es/EmbeddedNode.java
@@ -1,8 +1,11 @@
 package org.exoplatform.addons.es;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.common.cli.Terminal;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.node.internal.InternalSettingsPreparer;
 import org.elasticsearch.plugins.Plugin;
 
 import java.util.Collection;
@@ -15,8 +18,10 @@ public class EmbeddedNode extends Node {
   private Version version;
   private Collection<Class<? extends Plugin>> plugins;
 
-  public EmbeddedNode(Environment environment, Version version, Collection<Class<? extends Plugin>> classpathPlugins) {
-    super(environment, version, classpathPlugins);
+  public EmbeddedNode(Settings settings, Version version, Collection<Class<? extends Plugin>> classpathPlugins) {
+    // Use internal class (InternalSettingsPreparer) to create an Environment the same way it is done
+    // in standalone mode (load config file, system properties, replace placeholders, ...)
+    super(InternalSettingsPreparer.prepareEnvironment(settings, null), version, classpathPlugins);
     this.version = version;
     this.plugins = classpathPlugins;
   }


### PR DESCRIPTION
In order to take in account system properties to override default configuration, we now use the same internal mechanism than Elasticsearch uses when it starts in standalone mode to initialize the settings. This allows to use system properties correctly, but also to load config or plugins.
There is a drawback : it uses an internal class (InternalSettingsPreparer), so upgrades can be harder. But it allows to have the same behavior between embedded and standalone modes.
